### PR TITLE
Fix list validation

### DIFF
--- a/drf_compound_fields/fields.py
+++ b/drf_compound_fields/fields.py
@@ -45,7 +45,6 @@ class ListField(WritableField):
         return obj
 
     def from_native(self, data):
-        self.validate_is_list(data)
         if self.item_field and data:
             return [
                 self.item_field.from_native(item_data)


### PR DESCRIPTION
This causes spurious validation errors when using 'partial' serializers (PATCH requests) in DRF

I first noticed it because I would see errors like `picture_ids: %(value)s is not a list` in my tests while working on DD-13356

I started looking into why the `%(value)s` was not substituted, suspecting a bug in our error response code

but it turns out due to error being raised in the wrong phase

when validation is performed at the normal time by DRF the value gets substituted properly https://github.com/encode/django-rest-framework/blob/2.4.4/rest_framework/fields.py#L326

I confirmed also that the `validate_is_list` still gets called when expected after removing this line
(by the other call here https://github.com/depop/drf-compound-fields/pull/1/files#diff-eda3067cafbcf5832b69773cf900e5e6R58)