### PR TITLE
Don't run validation when value is None for DictFields

### DIFF
--- a/drf_compound_fields/fields.py
+++ b/drf_compound_fields/fields.py
@@ -190,7 +190,7 @@ class DictField(WritableField):
 
         self.validate_is_dict(value)
 
-        if self.value_field:
+        if self.value_field and value is not None:
             errors = {}
             for k, v in six.iteritems(value):
                 try:
@@ -204,7 +204,7 @@ class DictField(WritableField):
     def run_validators(self, value):
         super(DictField, self).run_validators(value)
 
-        if self.value_field:
+        if self.value_field and value is not None:
             errors = {}
             for k, v in six.iteritems(value):
                 try:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 setup(
     name='drf-compound-fields',
-    version='0.2.2.post2',
+    version='0.2.2.post3',
     description='Django-REST-framework serializer fields for compound types.',
     long_description=readme + '\n\n' + history,
     author='Steven Cummings',


### PR DESCRIPTION
This is the same as PR #2 but for `DictField` also :) 